### PR TITLE
:sparkles: feat: message parser function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+ircserv
+*workspace
+*log
+
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ SRC_DIR		=	src
 OBJ_DIR		=	obj
 INC_DIR		=	inc
 
-SRC			= $(SRC_DIR)/main.cpp
+SRC			= $(SRC_DIR)/main.cpp \
+			$(SRC_DIR)/Message.cpp
+
 OBJ 		= $(SRC:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
 
 all: $(NAME)

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1,0 +1,48 @@
+/* ****************************************************************************/
+/*  ROFL:ROFL:ROFL:ROFL 													  */
+/*          _^___      										 				  */
+/* L     __/   [] \    										 			      */
+/* LOL===__        \   			MY ROFLCOPTER GOES BRRRRRR				  	  */
+/* L      \________]  					by fdessoy-				  			  */
+/*         I   I     			(fdessoy-@student.hive.fi)				  	  */
+/*        --------/   										  				  */
+/* ****************************************************************************/
+
+# include "Message.hpp"
+
+// Constructor
+Message::Message(std::string rawMessage)
+{
+	parseIncommingMessage(rawMessage);
+}
+
+// Getters
+std::string Message::getPrefix()
+{
+	return (prefix_);
+}
+
+std::string Message::getCommand()
+{
+	return (command_);
+}
+
+std::string Message::getParams()
+{
+	return (params_);
+}
+
+std::string Message::getSuffix()
+{
+	return (suffix_);
+}
+
+std::string Message::getSender()
+{
+	return (sender_);
+}
+
+std::string Message::getRecipient()
+{
+	return (recipient_);
+}

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -16,33 +16,82 @@ Message::Message(std::string rawMessage)
 	parseIncommingMessage(rawMessage);
 }
 
+void Message::parseIncommingMessage(std::string rawMessage)
+{
+	// Check for CRLF termination
+	if (rawMessage.size() < 2 || rawMessage.substr(rawMessage.size() - 2) != "\r\n") {
+		throw std::invalid_argument("Invalid message format (no CRLF at the end)");
+	}
+	// Remove CRLF
+	rawMessage = rawMessage.substr(0, rawMessage.size() - 2);
+
+	// Parse sections
+	size_t pos;
+	// Parse prefix
+	if(rawMessage[0] == ':')
+	{
+		size_t spacePos = rawMessage.find(' ');
+		if(spacePos == std::string::npos)
+			throw std::invalid_argument("Invalid message format (no space after prefix)");
+		prefix_ =  rawMessage.substr(0, spacePos - 1);
+		pos = spacePos + 1;
+	}
+
+	// Parse command
+	size_t spacePos = rawMessage.find(' ', pos);
+	if(spacePos == std::string::npos)
+	{
+		command_ = rawMessage.substr(pos);
+		return;
+	}
+	command_ = rawMessage.substr(pos, spacePos - pos);
+	pos = spacePos + 1;
+
+	// Parse params and body
+	size_t colonPos = rawMessage.find(':', pos);
+	if (colonPos != std::string::npos) {
+		params_ = rawMessage.substr(pos, colonPos - pos);
+		suffix_ = rawMessage.substr(colonPos + 1);
+	} else {
+		params_ = rawMessage.substr(pos);
+	}
+
+}
+
+std::string Message::serialize()
+{
+	// TODO: the message format differ based on the command
+	std::string message = prefix_ + " " + command_ + " " + params_ + " :" + suffix_ + "\r\n";
+	return message;
+}
+
 // Getters
-std::string Message::getPrefix()
+std::string Message::getPrefix() const
 {
 	return (prefix_);
 }
 
-std::string Message::getCommand()
+std::string Message::getCommand() const
 {
 	return (command_);
 }
 
-std::string Message::getParams()
+std::string Message::getParams() const
 {
 	return (params_);
 }
 
-std::string Message::getSuffix()
+std::string Message::getSuffix() const
 {
 	return (suffix_);
 }
 
-std::string Message::getSender()
+std::string Message::getSender() const
 {
 	return (sender_);
 }
 
-std::string Message::getRecipient()
+std::string Message::getRecipient() const
 {
 	return (recipient_);
 }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -33,7 +33,7 @@ void Message::parseIncommingMessage(std::string rawMessage)
 		size_t spacePos = rawMessage.find(' ');
 		if(spacePos == std::string::npos)
 			throw std::invalid_argument("Invalid message format (no space after prefix)");
-		prefix_ =  rawMessage.substr(0, spacePos - 1);
+		prefix_ =  rawMessage.substr(1, spacePos - 1);
 		pos = spacePos + 1;
 	}
 
@@ -50,7 +50,7 @@ void Message::parseIncommingMessage(std::string rawMessage)
 	// Parse params and body
 	size_t colonPos = rawMessage.find(':', pos);
 	if (colonPos != std::string::npos) {
-		params_ = rawMessage.substr(pos, colonPos - pos);
+		params_ = rawMessage.substr(pos, colonPos - pos - 1);
 		suffix_ = rawMessage.substr(colonPos + 1);
 	} else {
 		params_ = rawMessage.substr(pos);
@@ -61,7 +61,7 @@ void Message::parseIncommingMessage(std::string rawMessage)
 std::string Message::serialize()
 {
 	// TODO: the message format differ based on the command
-	std::string message = prefix_ + " " + command_ + " " + params_ + " :" + suffix_ + "\r\n";
+	std::string message = ":" + prefix_ + " " + command_ + " " + params_ + " :" + suffix_ + "\r\n";
 	return message;
 }
 

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -22,11 +22,10 @@ void Message::parseIncommingMessage(std::string rawMessage)
 	if (rawMessage.size() < 2 || rawMessage.substr(rawMessage.size() - 2) != "\r\n") {
 		throw std::invalid_argument("Invalid message format (no CRLF at the end)");
 	}
-	// Remove CRLF
 	rawMessage = rawMessage.substr(0, rawMessage.size() - 2);
 
 	// Parse sections
-	size_t pos;
+	size_t pos = 0;
 	// Parse prefix
 	if(rawMessage[0] == ':')
 	{
@@ -39,8 +38,10 @@ void Message::parseIncommingMessage(std::string rawMessage)
 
 	// Parse command
 	size_t spacePos = rawMessage.find(' ', pos);
+	std::cout << "Command:\n";
 	if(spacePos == std::string::npos)
 	{
+		std::cout << "Only Command:\n";
 		command_ = rawMessage.substr(pos);
 		return;
 	}
@@ -60,8 +61,21 @@ void Message::parseIncommingMessage(std::string rawMessage)
 
 std::string Message::serialize()
 {
-	// TODO: the message format differ based on the command
-	std::string message = ":" + prefix_ + " " + command_ + " " + params_ + " :" + suffix_ + "\r\n";
+	std::string message;
+
+	if (!prefix_.empty())
+		message += ":" + prefix_ + " ";
+
+	if (!command_.empty())
+		message += command_;
+
+	if (!params_.empty())
+		message += " " + params_;
+
+	if (!suffix_.empty())
+		message += " :" + suffix_;
+
+	message += "\r\n";
 	return message;
 }
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -1,0 +1,33 @@
+/* ****************************************************************************/
+/*  ROFL:ROFL:ROFL:ROFL 													  */
+/*          _^___      										 				  */
+/* L     __/   [] \    										 			      */
+/* LOL===__        \   			MY ROFLCOPTER GOES BRRRRRR				  	  */
+/* L      \________]  					by fdessoy-				  			  */
+/*         I   I     			(fdessoy-@student.hive.fi)				  	  */
+/*        --------/   										  				  */
+/* ****************************************************************************/
+
+# include <iostream>
+
+class Message
+{
+	private:
+		std::string prefix_;
+		std::string command_;
+		std::string params_;
+		std::string suffix_;
+		std::string sender_;
+		std::string recipient_;
+
+	public:
+		Message(std::string rawMessage);
+		std::string getPrefix();
+		std::string getCommand();
+		std::string getParams();
+		std::string getSuffix();
+		std::string getSender();
+		std::string getRecipient();
+		void parseIncommingMessage(std::string rawMessage);
+		std::string serialize();
+};

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -19,15 +19,15 @@ class Message
 		std::string suffix_;
 		std::string sender_;
 		std::string recipient_;
+		void parseIncommingMessage(std::string rawMessage);
 
 	public:
 		Message(std::string rawMessage);
-		std::string getPrefix();
-		std::string getCommand();
-		std::string getParams();
-		std::string getSuffix();
-		std::string getSender();
-		std::string getRecipient();
-		void parseIncommingMessage(std::string rawMessage);
+		std::string getPrefix() const;
+		std::string getCommand() const;
+		std::string getParams() const;
+		std::string getSuffix() const;
+		std::string getSender() const;
+		std::string getRecipient() const;
 		std::string serialize();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,10 +174,14 @@ int main(int argc, char **argv)
 			try {
 				std::string rawMessage = std::string(buffer) + "\r\n";
 				Message msg(rawMessage);
-				std::cout << "Prefix: " << msg.getPrefix() << "\n";
-				std::cout << "Command: " << msg.getCommand() << "\n";
-				std::cout << "Params: " << msg.getParams() << "\n";
-				std::cout << "Suffix: " << msg.getSuffix() << "\n";
+				std::cout << "Prefix:_" << msg.getPrefix() << "_\n";
+				std::cout << "Command:_" << msg.getCommand() << "_\n";
+				std::cout << "Params:_" << msg.getParams() << "_\n";
+				std::cout << "Suffix:_" << msg.getSuffix() << "_\n";
+
+				std::cout << "Serialized msg:\n";
+				std::string serMSG = msg.serialize();
+				std::cout << serMSG << "\n";
 			} catch (const std::exception& e) {
 				std::cerr << "Error: " << e.what() << "\n";
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <poll.h>
+# include "Message.hpp"
 
 /**
  * TO DO 
@@ -169,7 +170,17 @@ int main(int argc, char **argv)
 				return (EXIT_FAILURE);
 			}
 			buffer[bytes_read] = '\0';
-			std::cout << "Message: " << buffer << std::endl;
+			//std::cout << "Message: " << buffer << std::endl;
+			try {
+				std::string rawMessage = std::string(buffer) + "\r\n";
+				Message msg(rawMessage);
+				std::cout << "Prefix: " << msg.getPrefix() << "\n";
+				std::cout << "Command: " << msg.getCommand() << "\n";
+				std::cout << "Params: " << msg.getParams() << "\n";
+				std::cout << "Suffix: " << msg.getSuffix() << "\n";
+			} catch (const std::exception& e) {
+				std::cerr << "Error: " << e.what() << "\n";
+	}
 			close(client_fd); // at this point we are taking one message and closing the fd
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,9 @@ int main(int argc, char **argv)
 			buffer[bytes_read] = '\0';
 			//std::cout << "Message: " << buffer << std::endl;
 			try {
-				std::string rawMessage = std::string(buffer) + "\r\n";
+				std::string rawMessage = std::string(buffer);
+				rawMessage.pop_back();
+				rawMessage += "\r\n";
 				Message msg(rawMessage);
 				std::cout << "Prefix:_" << msg.getPrefix() << "_\n";
 				std::cout << "Command:_" << msg.getCommand() << "_\n";


### PR DESCRIPTION
Add a parser for incoming messages from the Client.

The code defines a Message class with a constructor that takes a `rawMessage` from the Client and parses it using `parseIncommingMessage`. The only validation for now is that the string has to end in `\r\n` characters and consequently that it must be longer than 2 chars.

After this checks it parses the four possible fields, defined by spaces and colon presence, based on this schema:

  `[ ":" <prefix> <SPACE> ] <command> <params> [ " :" <suffix> ] <CR><LF>`

If the field exits, it is stored as private members accordingly.

A `serializer` function is also added. This represents the message we will create to return to the Client(s) as needed. For now, it just appends the fields if they are present, but this has to be properly handled with format validation.

Boilerplate getters are also added