### PR TITLE
JOIN + PART

### DIFF
--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/30 11:02:47 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/30 15:25:48 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,15 +27,17 @@ class Channel
 		std::string				_topic;
 		std::set<Client*>		_members;
 		std::set<Client*>		_operators;
-		bool 					_isPrivate;
-		bool					_isInviteOnly;
+		std::string				_key;
+		bool 					_isPrivate; // private channels are set by MODE flag
+		bool					_isInviteOnly; // same as private
 		void 					setName( const std::string& name );
 	public:
-		Channel(const std::string &name, const std::string &topic, bool isPrivate, bool isInviteOnly);
+		Channel(const std::string &name, const std::string &key, const std::string &topic, bool isPrivate, bool isInviteOnly);
 		~Channel();
 
 		// Getters
 		const std::string 		getName() const;
+		const std::string		getKey() const;
 		const std::string 		getTopic() const;
 		const std::set<Client*> getMembers() const;
 		const std::set<Client*> getOperators() const;
@@ -44,6 +46,7 @@ class Channel
 
 		// Setters
 		void					setTopic(const std::string& newTopic);
+		void					setKey(const std::string& key);
 		void					setPrivate(bool isPrivate);
 		void					setInviteOnly(bool isInviteOnly);
 
@@ -52,6 +55,7 @@ class Channel
 		bool					removeMember(Client* client);
 		bool					addOperator(Client* channelOperator, Client* target);
 		bool					removeOperator(Client* channelOperator, Client* target, bool leaving);
+		bool					changeKey(Client* channelOperator, std::string newKey);
 		
 		// Utility
 		bool 					isMember(Client* client) const;

--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/27 12:51:30 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/29 09:38:46 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,27 +35,27 @@ class Channel
 		~Channel();
 
 		// Getters
-		const		std::string getName() const;
-		const		std::string getTopic() const;
-		const		std::set<Client*> getMembers() const;
-		const		std::set<Client*> getOperators() const;
-		const bool&	getIsPrivate() const;
-		const bool&	getIsInviteOnly() const;
+		const std::string 		getName() const;
+		const std::string 		getTopic() const;
+		const std::set<Client*> getMembers() const;
+		const std::set<Client*> getOperators() const;
+		const bool&				getIsPrivate() const;
+		const bool&				getIsInviteOnly() const;
 
 		// Setters
-		void		setTopic(const std::string& newTopic);
-		void		setPrivate(bool isPrivate);
-		void		setInviteOnly(bool isInviteOnly);
+		void					setTopic(const std::string& newTopic);
+		void					setPrivate(bool isPrivate);
+		void					setInviteOnly(bool isInviteOnly);
 
 		// Membership management
-		bool		addOperator(Client* client);
-		void		addMember(Client* client);
-		bool		removeMember(Client* client);
-		bool		removeOperator(Client* client);
+		bool					addOperator(Client* client);
+		void					addMember(Client* client);
+		bool					removeMember(Client* client);
+		bool					removeOperator(Client* client);
 		
 		// Utility
-		bool 		isMember(Client* client) const;
-		bool 		isOperator(Client* client) const;
-		bool		isChannelEmpty() const;
+		bool 					isMember(Client* client) const;
+		bool 					isOperator(Client* client) const;
+		bool					isChannelEmpty() const;
 
 };

--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 09:38:46 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/30 11:02:47 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,14 +48,15 @@ class Channel
 		void					setInviteOnly(bool isInviteOnly);
 
 		// Membership management
-		bool					addOperator(Client* client);
 		void					addMember(Client* client);
 		bool					removeMember(Client* client);
-		bool					removeOperator(Client* client);
+		bool					addOperator(Client* channelOperator, Client* target);
+		bool					removeOperator(Client* channelOperator, Client* target, bool leaving);
 		
 		// Utility
 		bool 					isMember(Client* client) const;
 		bool 					isOperator(Client* client) const;
 		bool					isChannelEmpty() const;
+		bool					noOperators() const;
 
 };

--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fdessoy- <fdessoy-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/15 15:20:46 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/27 12:51:30 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,4 +56,6 @@ class Channel
 		// Utility
 		bool 		isMember(Client* client) const;
 		bool 		isOperator(Client* client) const;
+		bool		isChannelEmpty() const;
+
 };

--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -21,7 +21,7 @@ class Client
 		std::string			_clientHost;
 		int 				_clientFd;
 		socklen_t			_clientAddrLen;
-		struct pollfd		*_fds;
+		struct pollfd*		_fds;
 		std::string			_nick;
 		std::string			_user;
 		std::string			_realName;

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -55,38 +55,38 @@ class Server
 		~Server();
 
 		// getters
-		int			getPort();
-		int			getSocket();
-		const sockaddr_in	&getServerAddr() const;
+		int							getPort();
+		int							getSocket();
+		const sockaddr_in&			getServerAddr() const;
 		// pollfd		*getFdPoll();
 
 		// setters
-		void		setSocket( int socket );
-		void		setServerAddr();
+		void						setSocket( int socket );
+		void						setServerAddr();
 
 
 		// public methods
-		void portConversion( std::string port );
-		void Run();
-		void AddClient( int clientFd, sockaddr_in clientAddr, socklen_t clientAddrLen );
-		void BroadcastMessage(std:: string &messasge);
-		void SendToClient(Client& client, const std::string& message);
-		void sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender);
-		void handleMessage(Client& client, const std::string& message);
+		void 						portConversion( std::string port );
+		void 						Run();
+		void 						AddClient( int clientFd, sockaddr_in clientAddr, socklen_t clientAddrLen );
+		void 						BroadcastMessage(std:: string &messasge);
+		void 						SendToClient(Client& client, const std::string& message);
+		void 						SendToChannel(const std::string& channelName, const std::string& message, Client* sender, bool justJoined);
+		void 						handleMessage(Client& client, const std::string& message);
 
 		// Command handlers
-		void Ping(Client& client, const std::string& message);
-		void Pong(Client& client, const std::string& message);
-		void Cap(Client& client, const std::string& message);
-		void Nick(Client& client, const std::string& message);
-		void User(Client& client, const std::string& message);
-		void Mode(Client& client, const std::string& message);
-		void Join(Client& client, const std::string& message);
-		void Quit(Client& client, const std::string& message);
-		void Priv(Client& client, const std::string& message);
-		void Part(Client& client, const std::string& message);
+		void 						Ping(Client& client, const std::string& message);
+		void 						Pong(Client& client, const std::string& message);
+		void 						Cap(Client& client, const std::string& message);
+		void 						Nick(Client& client, const std::string& message);
+		void 						User(Client& client, const std::string& message);
+		void 						Mode(Client& client, const std::string& message);
+		void 						Join(Client& client, const std::string& message);
+		void 						Quit(Client& client, const std::string& message);
+		void 						Priv(Client& client, const std::string& message);
+		void 						Part(Client& client, const std::string& message);
 
-		void initializeCommandHandlers();
-		std::vector<std::string> splitMessages(const std::string& message);
+		void 						initializeCommandHandlers();
+		std::vector<std::string>	splitMessages(const std::string& message);
 
 };

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -84,6 +84,7 @@ class Server
 		void Join(Client& client, const std::string& message);
 		void Quit(Client& client, const std::string& message);
 		void Priv(Client& client, const std::string& message);
+		void Part(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -97,7 +97,6 @@ void Channel::setInviteOnly( bool isInviteOnly )
 // Membership management
 void Channel::addMember(Client* client)
 {
-	// if the member is the first to enter the server, we shall call addOperator
 	if (_members.empty())
 		addOperator(client);
 	_members.emplace(client);
@@ -166,5 +165,12 @@ bool Channel::isOperator(Client* client) const
 		if ((possibleOperator->getNick() == client->getNick() || possibleOperator->getUser() == client->getNick()) && (possibleOperator->getClientFd() == client->getClientFd()))
 			return (true);
 	}
+	return (false);
+}
+
+bool Channel::isChannelEmpty() const
+{
+	if (_members.empty())
+		return (true);
 	return (false);
 }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -10,9 +10,10 @@
 
 #include "../inc/Channel.hpp"
 
-Channel::Channel(const std::string &name, const std::string &topic, bool IsPrivate, bool isInviteOnly )
+Channel::Channel(const std::string &name, const std::string &key, const std::string &topic, bool IsPrivate, bool isInviteOnly )
 {
 	setName(name);
+	setKey(key);
 	setTopic(topic);
 	setPrivate(IsPrivate);
 	setInviteOnly(isInviteOnly);
@@ -20,7 +21,6 @@ Channel::Channel(const std::string &name, const std::string &topic, bool IsPriva
 
 Channel::~Channel()
 {
-	
 }
 
 // Channel::Channel( const Channel& ref )
@@ -46,6 +46,11 @@ Channel::~Channel()
 const std::string Channel::getName() const
 {
 	return (_name);
+}
+
+const std::string Channel::getKey() const
+{
+	return (_key);
 }
 
 const std::string Channel::getTopic() const
@@ -77,6 +82,11 @@ const bool& Channel::getIsInviteOnly() const
 void Channel::setName( const std::string& name )
 {
 	_name = name;
+}
+
+void Channel::setKey( const std::string& key )
+{
+	_key = key;
 }
 
 void Channel::setTopic( const std::string& newTopic )
@@ -117,9 +127,13 @@ bool Channel::addOperator(Client* channelOperator, Client* target)
 {
 	if (!this->noOperators())
 	{
+		std::cout << "we got inside the no operator clause, which shouldn't happen" << std::endl;
 		if (!this->isOperator(channelOperator) || !this->isMember(channelOperator)
 			|| !this->isMember(target) || this->isOperator(target))
+		{
+			std::cout << "we got inside the clause " << std::endl;
 			return (false);
+		}
 	}
 	_operators.emplace(target);
 	return (true);
@@ -132,11 +146,21 @@ bool	Channel::removeOperator(Client* channelOperator, Client* target, bool leavi
 		if (!this->isOperator(channelOperator) || !this->isMember(channelOperator))
 			return (false);
 		_operators.erase(channelOperator);
+		return (true);
 	}
 	if (!this->isOperator(channelOperator) || !this->isMember(channelOperator)
 		|| !this->isMember(target) || !this->isOperator(target))
 		return (false);
 	_operators.erase(target);
+	return (true);
+}
+
+bool	Channel::changeKey( Client* channelOperator, std::string newKey )
+{
+	if (!this->isMember(channelOperator) || !this->isOperator(channelOperator)
+		|| newKey == this->_key)
+		return (false);
+	this->setKey(newKey);
 	return (true);
 }
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -104,10 +104,10 @@ void Channel::addMember(Client* client)
 
 bool Channel::removeMember(Client* client)
 {
-	auto it = _operators.find(client);
-	if (it != _operators.end())
+	auto it = _members.find(client);
+	if (it != _members.end())
 	{
-		_operators.erase(it);
+		_members.erase(it);
 		return (true);
 	}
 	return (false);
@@ -137,7 +137,6 @@ bool Channel::removeOperator(Client* client)
 		return (true);
 	}
 	return (false);
-
 }
 
 // Channel settings
@@ -150,7 +149,7 @@ bool Channel::isMember(Client* client) const
 	{
 		Client* possibleMember = *it;
 
-		if ((possibleMember->getUser() == client->getUser()))
+		if ((possibleMember->getClientFd() == client->getClientFd()))
 			return (true);
 	}
 	return (false);
@@ -162,7 +161,7 @@ bool Channel::isOperator(Client* client) const
 	{
 		Client* possibleOperator = *it;
 		
-		if (possibleOperator->getUser() == client->getNick())
+		if (possibleOperator->getClientFd() == client->getClientFd())
 			return (true);
 	}
 	return (false);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -119,7 +119,7 @@ bool Channel::addOperator(Client* client)
 	{
 		Client* existingClient = *it;
 
-		if ((existingClient->getNick() == client->getNick() || existingClient->getUser() == client->getNick()) && (existingClient->getClientFd() == client->getClientFd()))
+		if (existingClient->getUser() == client->getUser())
 		{
 			return (true);
 		}
@@ -150,7 +150,7 @@ bool Channel::isMember(Client* client) const
 	{
 		Client* possibleMember = *it;
 
-		if ((possibleMember->getNick() == client->getNick() || possibleMember->getUser() == client->getNick()) && (possibleMember->getClientFd() == client->getClientFd()))
+		if ((possibleMember->getUser() == client->getUser()))
 			return (true);
 	}
 	return (false);
@@ -162,7 +162,7 @@ bool Channel::isOperator(Client* client) const
 	{
 		Client* possibleOperator = *it;
 		
-		if ((possibleOperator->getNick() == client->getNick() || possibleOperator->getUser() == client->getNick()) && (possibleOperator->getClientFd() == client->getClientFd()))
+		if (possibleOperator->getUser() == client->getNick())
 			return (true);
 	}
 	return (false);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/27 12:55:12 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/27 17:05:01 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ void Server::initializeCommandHandlers()
 	_commands["MODE"] = [this](Client& client, const std::string& message) 		{Mode(client, message); };
 	_commands["PRIVMSG"] = [this](Client& client, const std::string& message) 	{Priv(client, message); };
 	_commands["JOIN"] = [this](Client& client, const std::string& message)		{Join(client, message); };
-	_commands["PART"] = [this](Client& client, const std::string& message)		{Join(client, message); };
+	_commands["PART"] = [this](Client& client, const std::string& message)		{Part(client, message); };
 	_commands["QUIT"] = [this](Client& client, const std::string& message) 		{Quit(client, message); };
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 13:07:30 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/29 13:33:59 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -414,6 +414,10 @@ void Server::Join(Client& client, const std::string& message)
 		_channels.emplace(channel, newChannel);
 		it = _channels.find(channel);
 	}
+	// if (!key.empty())
+	// {
+		
+	// }
 	
 	it->second.addMember(&client);
 	if (it->second.isMember(&client))
@@ -476,7 +480,7 @@ void Server::Part(Client& client, const std::string& message)
 		return ;
 	}
 	it->second.removeMember(&client);
-	SendToClient(client, ":" + client.getNick() + " PART " + "#" + channel + "\r\n");
+	SendToClient(client, ":" + client.getNick() + " PART " + channel + "\r\n");
 	if (it->second.isChannelEmpty())
 		_channels.erase(channel);
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/27 17:05:01 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/28 15:37:58 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -415,7 +415,8 @@ void Server::Join(Client& client, const std::string& message)
 	}
 	
 	it->second.addMember(&client);
-	SendToClient(client, ":" + client.getNick() + " JOIN " + channel + "\r\n");
+	if (it->second.isMember(&client))
+		SendToClient(client, ":" + client.getNick() + " JOIN " + channel + "\r\n");
 	// std::string namesList = "Server 353 " + client.getNick() + " = " + channel + " :"; // Need a method to the message when created
 	// for (Client* member : it->second.getMembers())
 	// {
@@ -439,7 +440,10 @@ void Server::sendMessageToChannel(const std::string& channelName, const std::str
 	for (Client* member : it->second.getMembers())
 	{
 		if (member != sender)
-			SendToClient(*member, message);
+		{
+			if (it->second.isMember(sender))
+				SendToClient(*member, message);
+		}
 	}
 }
 


### PR DESCRIPTION
## What's new

1. `JOIN` was technically working, but there were some problems in the `Channel` class methods. The checks for members and operators were incorrectly written, but now we check for the users `filedes` to check if they are members or not;
2. Only members of channels can message those channels directly. If one still tries, the answer given by zorg is: `Zorg: you are not a member of the channel <channel_name>`;
3. `PART` works, but it has some tiny discrepancy that it seems to work with or without the channel name, or the name can be incorrectly inputted. I will write in the `JOIN` & `PART` issue about this more thoroughly;
4. Members are greeted with messages and the list of members, as specified by RFC 1459:
![image](https://github.com/user-attachments/assets/c0877481-491d-4b4e-8d1a-92441501dc43)
