### PR TITLE
Refactor: connection handling and robust pass nick user

### DIFF
--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -27,6 +27,7 @@ class Client
 		std::string			_realName;
 		std::set<char>		_userModes;
 		int					_isAuthenticated = false;
+		std::string 		_readBuffer;
 	public:
 		// constructor
 		Client( int fd, const sockaddr_in& addr);
@@ -60,4 +61,8 @@ class Client
 		void	addMode(char mode);
 		void	removeMode(char mode);
 		std::string getModes() const;
+
+		void appendToBuffer(const std::string& data) { _readBuffer += data; }
+   		std::string& getBuffer() { return _readBuffer; }
+    	void clearBuffer() { _readBuffer.clear(); }
 };

--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -57,7 +57,4 @@ class Client
 		void	addMode(char mode);
 		void	removeMode(char mode);
 		std::string getModes() const;
-
-		// methods
-		int registerUser();
 };

--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -27,7 +27,7 @@ class Client
 		std::string			_realName;
 		std::set<char>		_userModes;
 		int					_isAuthenticated = false;
-		std::string 		_readBuffer;
+		int					_isRegistered = false;
 	public:
 		// constructor
 		Client( int fd, const sockaddr_in& addr);
@@ -45,6 +45,7 @@ class Client
 		const std::string	getUser() const;
 		const std::string	getRealname() const;
 		bool			getAuthentication() const;
+		bool			getRegistration() const;
 
 		// setters
 		void	setClientAddr( sockaddr_in clientAddr );
@@ -55,14 +56,11 @@ class Client
 		void	setUser( std::string user );
 		void	setRealname( std::string realname );
 		void	setAuthentication(bool auth);
+		void	setRegistration(bool reg);
 
 		//mode
 		bool	hasMode(char mode) const;
 		void	addMode(char mode);
 		void	removeMode(char mode);
 		std::string getModes() const;
-
-		void appendToBuffer(const std::string& data) { _readBuffer += data; }
-   		std::string& getBuffer() { return _readBuffer; }
-    	void clearBuffer() { _readBuffer.clear(); }
 };

--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -26,6 +26,7 @@ class Client
 		std::string			_user;
 		std::string			_realName;
 		std::set<char>		_userModes;
+		int					_isAuthenticated = false;
 	public:
 		// constructor
 		Client( int fd, const sockaddr_in& addr);
@@ -42,6 +43,7 @@ class Client
 		const std::string	getNick() const;
 		const std::string	getUser() const;
 		const std::string	getRealname() const;
+		bool			getAuthentication() const;
 
 		// setters
 		void	setClientAddr( sockaddr_in clientAddr );
@@ -51,6 +53,7 @@ class Client
 		void	setNick( std::string nick );
 		void	setUser( std::string user );
 		void	setRealname( std::string realname );
+		void	setAuthentication(bool auth);
 
 		//mode
 		bool	hasMode(char mode) const;

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -87,6 +87,7 @@ class Server
 		void Priv(Client& client, const std::string& message);
 		int  Pass(Client& client, const std::string& message);
 		void Stats(Client& client, const std::string& message);
+		void Whois(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -73,6 +73,7 @@ class Server
 		void handleMessage(Client& client, const std::string& message);
 		int connectionHandshake(Client& client, std::vector<std::string> messages);
 
+
 		// Command handlers
 		void Ping(Client& client, const std::string& message);
 		void Pong(Client& client, const std::string& message);
@@ -84,6 +85,7 @@ class Server
 		void Quit(Client& client, const std::string& message);
 		void Priv(Client& client, const std::string& message);
 		int  Pass(Client& client, const std::string& message);
+		void Stats(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -71,7 +71,7 @@ class Server
 		void SendToClient(Client& client, const std::string& message);
 		void sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender);
 		void handleMessage(Client& client, const std::string& message);
-		void connectionHandshake(Client& client, const std::string& receivedData);
+		int connectionHandshake(Client& client, const std::string& receivedData);
 
 		// Command handlers
 		void Ping(Client& client, const std::string& message);
@@ -83,7 +83,7 @@ class Server
 		void Join(Client& client, const std::string& message);
 		void Quit(Client& client, const std::string& message);
 		void Priv(Client& client, const std::string& message);
-		void Pass(Client& client, const std::string& message);
+		int  Pass(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -33,8 +33,6 @@ class Channel;
 
 using CommandHelper = std::function<void(Client&, const std::string&)>;
 
-using CommandHelper = std::function<void(Client&, const std::string&)>;
-
 class Server
 {
 	private:

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -76,6 +76,7 @@ class Server
 		void Mode(Client& client, const std::string& message);
 		void Quit(Client& client, const std::string& message);
 		void Priv(Client& client, const std::string& message);
+		void Join(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -71,6 +71,7 @@ class Server
 		void SendToClient(Client& client, const std::string& message);
 		void sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender);
 		void handleMessage(Client& client, const std::string& message);
+		void connectionHandshake(Client& client, const std::string& receivedData);
 
 		// Command handlers
 		void Ping(Client& client, const std::string& message);
@@ -82,7 +83,7 @@ class Server
 		void Join(Client& client, const std::string& message);
 		void Quit(Client& client, const std::string& message);
 		void Priv(Client& client, const std::string& message);
-		void Join(Client& client, const std::string& message);
+		void Pass(Client& client, const std::string& message);
 
 		void initializeCommandHandlers();
 		std::vector<std::string> splitMessages(const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -71,7 +71,7 @@ class Server
 		void SendToClient(Client& client, const std::string& message);
 		void sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender);
 		void handleMessage(Client& client, const std::string& message);
-		int connectionHandshake(Client& client, const std::string& receivedData);
+		int connectionHandshake(Client& client, std::vector<std::string> messages);
 
 		// Command handlers
 		void Ping(Client& client, const std::string& message);

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -44,6 +44,7 @@ class Server
 		std::vector<Client>						_clients;
 		std::map<std::string, Channel> 			_channels;
 		std::map<std::string, CommandHelper>	_commands;
+		void disconnectClient(Client& client);
 		
 	public:
 		// constructor

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:48 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/21 11:12:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/28 12:02:03 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,15 @@ void	Client::setClientFd( int clientFd )
 {
 	this->_clientFd = clientFd;
 }
+
+void Client::setAuthentication(bool auth){
+	this->_isAuthenticated = auth;
+}
+
+bool Client::getAuthentication() const{
+	return this->_isAuthenticated;
+}
+
 
 					// char buffer[1024];
                     // ssize_t bytes_read = read(fds[nfds].fd, buffer, sizeof(buffer) - 1);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:48 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/28 12:02:03 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/28 15:14:24 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,7 +94,10 @@ void	Client::setNick( std::string nick )
 
 const std::string	Client::getNick() const
 {
-	return (this->_nick);
+	if(this->_nick.empty())
+		return("*");
+	else
+		return (this->_nick);
 }
 
 void	Client::setUser( std::string user )

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:48 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/28 15:14:24 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 20:39:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,10 +94,10 @@ void	Client::setNick( std::string nick )
 
 const std::string	Client::getNick() const
 {
-	if(this->_nick.empty())
-		return("*");
-	else
-		return (this->_nick);
+	// if(this->_nick.empty())
+	// 	return("*");
+	// else
+	return (this->_nick);
 }
 
 void	Client::setUser( std::string user )

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:48 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 20:39:01 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 20:56:26 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,14 @@ void Client::setAuthentication(bool auth){
 
 bool Client::getAuthentication() const{
 	return this->_isAuthenticated;
+}
+
+void Client::setRegistration(bool reg){
+	this->_isRegistered = reg;
+}
+
+bool Client::getRegistration() const{
+	return this->_isRegistered;
 }
 
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/28 11:51:02 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/28 12:06:56 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -198,6 +198,7 @@ int Server::connectionHandshake(Client& client, const std::string& receivedData)
 			if(!grant_access){
 				return 0;
 			}
+			client.setAuthentication(true);
 		}
 		else if (command == "NICK"){
 			std::cout  << client.getClientFd() << " >> " << message << std::endl;
@@ -209,6 +210,12 @@ int Server::connectionHandshake(Client& client, const std::string& receivedData)
 			Server::User(client, message);
 			std::cout << std::endl;
 		}
+
+	}
+	std::cout << "Checking the authentication......." <<std::endl;
+	if(!client.getAuthentication()){
+		SendToClient(client, this->_name + " 464 " + client.getNick() +  ":Password incorrect\r\n");
+		return 0;
 	}
 	return 1;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Server.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akuburas <akuburas@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/14 14:47:35 by akuburas         ###   ########.fr       */
+/*   Updated: 2025/01/16 11:47:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@ void Server::initializeCommandHandlers()
 	_commands["MODE"] = [this](Client& client, const std::string& message) 		{Mode(client, message); };
 	_commands["PRIVMSG"] = [this](Client& client, const std::string& message) 	{Priv(client, message); };
 	_commands["QUIT"] = [this](Client& client, const std::string& message) 		{Quit(client, message); };
+	_commands["JOIN"] = [this](Client& client, const std::string& message) 		{Join(client, message); };
 }
 
 Server::~Server()
@@ -241,6 +242,15 @@ void Server::Nick(Client& client, const std::string& message)
 	}
 	client.setNick(nickname);
 	SendToClient(client, ":server-name 001 " + nickname + " :Welcome to the IRC network, " + nickname + "\r\n");
+}
+
+void Server::Join(Client& client, const std::string& message){
+	std::cout << "JOIN command received" << std::endl;
+	std::string nickname;
+	std::string command;
+	std::istringstream stream(message);
+	stream >> command >> nickname;
+	SendToClient(client, ":server-name 332 " + client.getNick() + " :Welcome to the server" + "/n/r");
 }
 
 void Server::User(Client& client, const std::string& message)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 15:51:49 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 16:04:04 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -361,6 +361,11 @@ void Server::Nick(Client& client, const std::string& message)
 
 void Server::User(Client& client, const std::string& message)
 {
+	if(!client.getUser().empty()){
+		SendToClient(client, ":" + _name + " 462 "+ client.getNick() + " USER :You may not reregister\r\n");
+		return;
+	}
+
 	std::istringstream stream(message);
 	std::string command, username, hostname, servername, realname;
 
@@ -370,14 +375,14 @@ void Server::User(Client& client, const std::string& message)
 		realname = realname.substr(2);
 	if (username.empty())
 	{
-		SendToClient(client, ":" +this->_name + " 461 * USER :Not enough parameters\r\n");
+		SendToClient(client, ":" + _name + " 461 "+ client.getNick() + "USER :Not enough parameters\r\n");
 		return;
 	}
 	client.setUser(username);
 	client.setRealname(realname);
 	// Check if registration is complete (PASS + NICK + USER)
 	if (client.getAuthentication() && !client.getNick().empty() && !client.getUser().empty()) {
-		    SendToClient(client, ":" + _name + " 001 " + client.getNick() + " :Welcome to the server\r\n");
+			SendToClient(client, ":" + _name + " 001 " + client.getNick() + " :Welcome to the server\r\n");
 		}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 16:04:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 20:10:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -169,7 +169,7 @@ void	Server::Run()
 
 int Server::connectionHandshake(Client& client, std::vector<std::string> messages) {
 
-	std::cout << "Connection Handshake......." << std::endl;
+	std::cout << "[Zorg] Connection Handshake......." << std::endl;
 	for(const std::string& message : messages) {
 		std::istringstream stream(message);
 		std::string command;
@@ -348,8 +348,11 @@ void Server::Nick(Client& client, const std::string& message)
 	// All is good. Set nick
 	std::string oldNickname = client.getNick();
 	client.setNick(newNickname);
-	SendToClient(client, ":" + oldNickname + "!" + client.getUser() + "@" + client.getHost() + " NICK " + client.getNick() + "\r\n");
-
+	if (oldNickname == "*" || oldNickname.empty())
+		SendToClient(client, ":" + _name + " 001 " + newNickname + " :Welcome to the IRC server\r\n");
+	// else
+	// 	SendToClient(client, ":" + oldNickname + "!" + client.getUser() + "@" + client.getHost() + " NICK :" + client.getNick() + "\r\n");
+		
 	// NOT IMPLEMENTED
 	// ERR_NICKCOLLISION not implemented
 			//-> same nickname in two servers
@@ -392,17 +395,17 @@ void Server::Ping(Client& client, const std::string& message)
 	if (pos == std::string::npos || pos + 1 >= message.size())
 	
 	{
-	    SendToClient(client, ":server 409 ERR_NOORIGIN :No origin specified\n");
+	    SendToClient(client, ":server 409 ERR_NOORIGIN :No origin specified\r\n");
 		return;
 	}
 	std::string server1 = message.substr(pos + 1);
 	if (server1.empty())
 	{
-		SendToClient(client, ":server 409 ERR_NOORIGIN :No origin specified\n");
+		SendToClient(client, ":server 409 ERR_NOORIGIN :No origin specified\r\n");
 		return;
 	}
 	//PONG response.
-	SendToClient(client, "PONG " + server1 + "\n");
+	SendToClient(client, "PONG " + server1 + "\r\n");
 }
 
 void Server::Mode(Client& client, const std::string& message)
@@ -413,12 +416,12 @@ void Server::Mode(Client& client, const std::string& message)
 
 	if (nickname != client.getNick())
 	{
-		SendToClient(client, ":server 502 ERR_USERSDONTMATCH :Cannot change mode for another user\n");
+		SendToClient(client, ":server 502 ERR_USERSDONTMATCH :Cannot change mode for another user\r\n");
 		return;
 	}
 	if (modeChanges.empty())
 	{
-		SendToClient(client, ":server 221 RPL_UMODEIS " + client.getModes() + "\n");
+		SendToClient(client, ":server 221 RPL_UMODEIS " + client.getModes() + "\r\n");
         return;
 	}
 	bool adding = true;
@@ -438,7 +441,7 @@ void Server::Mode(Client& client, const std::string& message)
 				client.removeMode(ch);
 		}
 		else
-			SendToClient(client, ":server 501 ERR_UMODEUNKNOWNFLAG :Unknown mode flag\n");
+			SendToClient(client, ":server 501 ERR_UMODEUNKNOWNFLAG :Unknown mode flag\r\n");
 	}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/28 11:18:35 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/28 11:51:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -162,6 +162,7 @@ void	Server::Run()
 							{
 								std::cout  << fds[i].fd << " >> " << message << std::endl;
 								handleMessage(*client, message);
+								std::cout << std::endl;
 							}
 						}
 					}
@@ -177,16 +178,36 @@ int Server::connectionHandshake(Client& client, const std::string& receivedData)
 
 	for (const auto& message : messages)
 	{
+		std::istringstream stream(message);
+		std::string command;
+		stream >> command;
 		// /connect 127.0.0.1 6667
-		// std::cout  << client.getFds() << " >> " << message << std::endl;
-		if(message.find("CAP")){
+		//std::cout  << client.getFds() << " >> " << message << std::endl;
+
+		// Convert command to uppercase
+		std::transform(command.begin(), command.end(), command.begin(), ::toupper);
+		if(command == "CAP"){
+			std::cout  << client.getClientFd() << " >> " << message << std::endl;
 			Server::Cap(client, message);
+			std::cout << std::endl;
 		}
-		else if(message.find("PASS")){
+		else if(command == "PASS"){
+			std::cout  << client.getClientFd() << " >> " << message << std::endl;
 			int grant_access = Server::Pass(client, message);
+			std::cout << std::endl;
 			if(!grant_access){
 				return 0;
 			}
+		}
+		else if (command == "NICK"){
+			std::cout  << client.getClientFd() << " >> " << message << std::endl;
+			Server::Nick(client, message);
+			std::cout << std::endl;
+		}
+		else if (command == "USER"){
+			std::cout  << client.getClientFd() << " >> " << message << std::endl;
+			Server::User(client, message);
+			std::cout << std::endl;
 		}
 	}
 	return 1;
@@ -474,6 +495,7 @@ int Server::Pass(Client& client, const std::string& message){
 		return 0;
 	}
 	if(password != this->_password){
+		std::cout << "Password sent by irssi is: " << password << std::endl;
 		SendToClient(client, this->_name + " 464 " + client.getNick() +  ":Password incorrect\r\n");
 		return 0;
 	}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/29 11:43:22 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 15:09:46 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -512,18 +512,23 @@ int Server::Pass(Client& client, const std::string& message){
 	std::string command, password;
 
 	stream >> command >> password;
+	if(client.getAuthentication()){
+		SendToClient(client, ":" + _name + " 462 " + client.getNick() + " :You may not reregister\r\n");
+		return 0;
+	}
 
 	if(password.empty()){
-		SendToClient(client, this->_name + " 461 " + client.getNick() +  "PASS :Not enough parameters\r\n");
+		SendToClient(client, _name + " 461 " + client.getNick() +  "PASS :Not enough parameters\r\n");
 		return 0;
 	}
-	if(password != this->_password){
-		SendToClient(client, this->_name + " 464 " + client.getNick() +  " :Password Incorrect\r\n");
+
+	if(password != _password){
+		SendToClient(client, _name + " 464 " + client.getNick() +  " :Password Incorrect\r\n");
 		return 0;
 	}
+	// no response message in case of correct PASS
 	std::cout << "[Zorg] password accepted" << std::endl;
 	return 1;
-	// no response message in case of correct PASS	
 }
 
 void Server::sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/22 13:11:39 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/23 09:21:53 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@
 Server::Server(int port, std::string password)
 {
 	this->_port = port;
-	this->_password = password; // need to check for password match
+	this->_password = password;
 	initializeCommandHandlers();
 }
 
@@ -39,7 +39,7 @@ void Server::initializeCommandHandlers()
 	_commands["PRIVMSG"] = [this](Client& client, const std::string& message) 	{Priv(client, message); };
 	_commands["JOIN"] = [this](Client& client, const std::string& message)		{Join(client, message); };
 	_commands["QUIT"] = [this](Client& client, const std::string& message) 		{Quit(client, message); };
-	_commands["JOIN"] = [this](Client& client, const std::string& message) 		{Join(client, message); };
+	_commands["PASS"] = [this](Client& client, const std::string& message) 		{Pass(client, message); };
 }
 
 Server::~Server()
@@ -422,6 +422,16 @@ void Server::Join(Client& client, const std::string& message)
         SendToClient(client, "Server 332 " + client.getNick() + " " + channel + " :" + it->second.getTopic() + "\r\n");
 	else // sends topic
         SendToClient(client, "Server 331 " + client.getNick() + " " + channel + " :No topic is set\r\n");
+}
+
+void Server::Pass(Client& client, const std::string& message){
+	std::istringstream stream(message);
+	std::string command, pass;
+
+	command >> pass;
+
+	
+	
 }
 
 void Server::sendMessageToChannel(const std::string& channelName, const std::string& message, Client* sender)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:45 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/23 10:35:10 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/28 11:39:23 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,6 +68,18 @@ bool	parsing(std::string port, std::string password)
 	return (true);
 }
 
+class fasdfasdf {
+   public:
+	   fasdfasdf();
+		~fasdfasdf();
+	   fasdfasdf(const fasdfasdf& other);
+	   fasdfasdf& operator=(const fasdfasdf& other);
+	   fasdfasdf(fasdfasdf&& other);
+	   fasdfasdf& operator=(fasdfasdf&& other);
+
+   private:
+	   // Add member variables here
+};
 int main(int argc, char **argv)
 {
 	if (argc != 3)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:45 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/28 11:39:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/01/29 21:29:33 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,18 +68,6 @@ bool	parsing(std::string port, std::string password)
 	return (true);
 }
 
-class fasdfasdf {
-   public:
-	   fasdfasdf();
-		~fasdfasdf();
-	   fasdfasdf(const fasdfasdf& other);
-	   fasdfasdf& operator=(const fasdfasdf& other);
-	   fasdfasdf(fasdfasdf&& other);
-	   fasdfasdf& operator=(fasdfasdf&& other);
-
-   private:
-	   // Add member variables here
-};
 int main(int argc, char **argv)
 {
 	if (argc != 3)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fdessoy- <fdessoy-@student.42.fr>          +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:45 by akuburas          #+#    #+#             */
-/*   Updated: 2025/01/10 14:44:53 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/01/23 10:35:10 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -126,6 +126,7 @@ int main(int argc, char **argv)
 	}
 	std::cout << "Server is listening in non-blocking mode" << std::endl;
 	std::cout << "Port: " << port << std::endl;
+	std::cout << "Pass: " << password << std::endl;
 
 	irc_server.Run();	
 	return (0);


### PR DESCRIPTION
 Correctly handle the connection between Irssi and Zorg.

> [!NOTE]
> `PONG` and other messages lack the proper ending (`\r\n`). As Irssi did not receive a proper response from these messages, probably Irssi has been confused and the "ghost" clients were reconnected as an attempt to recover the connection to the server. "Ghost" client problem seem to be solved.

### Major changes
By using the `connectionHandling` function, new users are forced to go through the ` PASS`  > ` NICK`  > ` USER`  pipeline until all is correctly set. To handle states, we set up two new members in `Client`:
-  `_isAuthenticated`: user provided the correct Server password.
- `_isRegistered`: The user has finished the connection handshake.

For new users with unique nicks, the steps are straightforward. If a new connection is attempted with a repeated nick, you don't achieve registered status. But Irssi will keep trying variations of the nick until one is accepted and the new user registered.

To achieve correct execution of the connection handshake,  ` PASS` , ` NICK`  and ` USER` commands had been updated with the proper error handling and error messaging.

In case of conflicts, Irssi uses `WHOIS` as part of the initial connection handling, so it also has been implemented.

### Minor changes
- The patch also implements 'STATS` command with the only option of `N`, to see the list of connected users. This can be expanded to see the list of channels and other information.
- Main loop has been clean a bit with a helper function to disconnect users
- Some error handling added to `SendToClient`