### PR TITLE
Multi join part

### DIFF
--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/07 09:57:28 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/02/07 12:17:17 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ class Channel
 		void					addMember(Client* client);
 		bool					removeMember(Client* client);
 		bool					addOperator(Client* channelOperator, Client* target);
-		bool					removeOperator(Client* channelOperator, Client* target, bool leaving);
+		bool					removeOperator(Client* channelOperator, Client* target);
 		bool					changeKey(Client* channelOperator, std::string newKey);
 		void 					limitMaxMembers( uint64_t limit );
 		

--- a/inc/Channel.hpp
+++ b/inc/Channel.hpp
@@ -3,18 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/18 11:18:19 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/05 10:02:00 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2025/02/07 09:57:28 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
-#include <iostream>
-#include <vector>
-#include <string>
 #include <set>
 #include <cstdint>
 #include "Client.hpp"

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/04 11:27:53 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/06 21:31:15 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/02/07 11:17:46 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@
 #include <map>
 #include <sstream>
 #include <ctime>
+
 #include "Channel.hpp"
 
 #define SERVER_NAME "Zorg"
@@ -92,7 +93,7 @@ class Server
 		int									connectionHandshake(Client& client, std::vector<std::string> messages, int fd);
 		void								ModeHelperChannel(Client &client, std::map<std::string, Channel>::iterator it, char mode, bool adding, std::string code);
 		bool 								MultipleChannels( const std::string& message );
-		std::map<std::string, std::string>	MapChannels( const std::string& message );
+		std::map<std::string, std::string>	MapChannels(const std::string& message );
 
 		// Command handlers
 		void 								Ping(Client& client, const std::string& message);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -191,9 +191,9 @@ bool Channel::addOperator(Client* channelOperator, Client* target)
 	return (true);
 }
 
-bool	Channel::removeOperator(Client* channelOperator, Client* target, bool leaving)
+bool	Channel::removeOperator(Client* channelOperator, Client* target)
 {
-	if (leaving)
+	if (target == nullptr)
 	{
 		if (!this->isOperator(channelOperator) || !this->isMember(channelOperator))
 			return (false);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/06 21:32:54 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/02/07 12:06:04 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -559,13 +559,18 @@ void Server::Mode(Client& client, const std::string& message)
 	{
 		for (auto it = _channels.begin(); it != _channels.end(); ++it)
 		{
-			if (it->second.getName() == target)
-				channel = true;
-			else
+			std::cout << "Target is: " << target << std::endl;
+			std::cout << "Our channel map match: " << it->first << std::endl;
+			if (it->first == target)
 			{
-				SendToClient(client, ":" + _name + " 403 " + target +  ": Invalid channel name\r\n");
-				return ;
+				channel = true;
+				break ;
 			}
+		}
+		if (channel == false)
+		{
+			SendToClient(client, ":" + _name + " 403 " + target +  ": Invalid channel name\r\n");
+			return ;
 		}
 	}
 	else
@@ -845,76 +850,6 @@ void Server::Quit(Client& client, const std::string& message)
 	std::cout << "[Zorg] Client " << client.getNick() << " has disconnected" << std::endl;;
 }
 
-void Server::Join(Client& client, const std::string& message)
-{
-	std::map<std::string, std::string>allChannels = MapChannels(message);
-	
-	std::istringstream stream(message);
-	std::string command, channel, key;
-	stream >> command >> channel >> key;
-	
-	if (channel.empty() || channel[0] != '#')
-	{
-		// ERR_BADCHANMASK
-		SendToClient(client, ":" + _name + " 476 " + client.getNick() + " " + channel + ":invalid channel name" + "\r\n");
-		return ;
-	}
-
-	auto it = _channels.find(channel);
-	if (it == _channels.end()) 
-	{
-		Channel newChannel(channel, key, "", false, false);
-		_channels.emplace(channel, newChannel);
-		it = _channels.find(channel);
-	}
-
-	// check if priovided key matches
-    if (!it->second.getKey().empty() && it->second.getKey() != key)
-    {
-        SendToClient(client, ":" + _name + " 475 " + client.getNick() + " " + channel + " :bad channel key\r\n");
-        return ;
-    }
-
-	// check if server has imposed limit
-	if (it->second.getMaxMembers())
-	{
-		// check if there is space
-		if (it->second.getNbMembers() >= it->second.getNumberMaxMembers())
-		{
-			SendToClient(client, ":" + _name + " 471 " + client.getNick() + " " + channel + " :channel is full\r\n");
-			return ;
-		}
-	}
-
-	it->second.addMember(&client);
-	if (it->second.isMember(&client))
-	{
-		SendToClient(client, ":" + client.getNick() + " JOIN " + channel + "\r\n");
-		std::string namesList;
-		for (Client* member : it->second.getMembers())
-		{
-			if (it->second.isOperator(member))
-				namesList += "@" + member->getNick() + " ";
-			else
-				namesList += member->getNick() + " ";
-		}
-		SendToClient(client, ":" + _name + " 353 " + client.getNick() + " = " + channel + " :" + namesList + "\r\n");
-		SendToClient(client, ":" + _name + " 366 " + client.getNick() + " " + channel + " :End of /NAMES list.\r\n");
-		if (!it->second.getTopic().empty())
-		{
-			SendToClient(client, ":" + _name + " 332 " + client.getNick() + " " + channel + " :" + it->second.getTopic() + "\r\n");
-			
-			SendToClient(client, ":" + _name + " 333 " + client.getNick() + " " + channel + " " + it->second.getSetter() + " " + std::to_string(it->second.getTopicTime()) + "\r\n");
-		}
-		else
-		{
-			SendToClient(client, ":" + _name + " 331 " + client.getNick() + " " + channel + " :No topic is set\r\n");
-		}
-		SendToChannel(it->second.getName(), ":" + client.getNick() + "!~" + client.getNick() + "@" + client.getHost() + " JOIN " + it->second.getName() + "\r\n", &client, NORMAL_MSG); // why does this crap is persisting?
-		//:fdessoy!~fdessoy@87-92-251-103.rev.dnainternet.fi JOIN #SUPER_BBQ
-	}
-}
-
 int Server::Pass(Client& client, const std::string& message){
 	std::istringstream stream(message);
 	std::string command, password;
@@ -984,36 +919,40 @@ void Server::SendToChannel(const std::string& channelName, const std::string& me
 void Server::Part(Client& client, const std::string& message)
 {
 	std::map<std::string, std::string>allChannels = MapChannels(message);
+	if (allChannels.empty())
+		return ;
 
-	// need to make multiple parts inside this whole thing
-    	std::istringstream stream(message);
-    	std::string command, channel;
-    	stream >> command >> channel;
+	for (auto it_map = allChannels.begin(); it_map != allChannels.end(); ++it_map)
+	{
+		std::string channel = it_map->first;
+		std::string key = it_map->second;
+
 		if (channel.empty() || channel[0] != '#')
 		{
 			// ERR_BADCHANMASK
 			SendToClient(client, ":" + _name + " 476 " + client.getNick() + " " + channel + " :Invalid channel syntax name\r\n");
-			return;
+			continue ;
 		}
+
 		auto it = _channels.find(channel);
 		if (it == _channels.end())
 		{
 			// ERR_NOSUCHCHANNEL
 			SendToClient(client, ":" + _name + " 403 " + client.getNick() + " " + channel + " :No such channel\r\n");
-			return;
+			continue ;
 		}
 
 		if (!it->second.isMember(&client))
 		{
 			SendToClient(client, ":" + _name + " 442 " + client.getNick() + " " + channel + " :You're not on that channel\r\n");
-			return;
+			continue ;
 		}
-		std::string partMessage = ":" + client.getNick() + "!~" + client.getNick() + "@" + client.getHost() + " PART " + channel + "\r\n";
-		SendToChannel(channel, partMessage, &client, NORMAL_MSG);
+		std::string partSyntax = ":" + client.getNick() + "!~" + client.getNick() + "@" + client.getHost() + " PART " + channel + "\r\n";
+		SendToChannel(channel, partSyntax, &client, NORMAL_MSG);
 		if (it->second.isOperator(&client))
-			it->second.removeOperator(&client, nullptr, NORMAL_MSG);
+			it->second.removeOperator(&client, nullptr, true);
 		it->second.removeMember(&client);
-		SendToClient(client, partMessage);
+		SendToClient(client, partSyntax);
 		if (it->second.isChannelEmpty())
 			_channels.erase(channel);
 	}
@@ -1022,33 +961,29 @@ void Server::Part(Client& client, const std::string& message)
 std::map<std::string, std::string>	Server::MapChannels( const std::string& message )
 {
 	std::istringstream 					stream(message);
-	std::vector<std::string> 			channels;
-	std::vector<std::string> 			keys;
 	std::map<std::string, std::string>	channelMap;
-	bool								parsingKeys = false;
-	std::string							token;
+	std::string command,channelsList,keysList;
 
-	if (!(stream >> token) || token != "/PART")
-	{
-		std::cerr << "Error" << std::endl;
-		return ;
-	}
+	// this will never happen, but might as well check
+    if (!(stream >> command) || (command != "PART" && command != "JOIN"))
+		return {};
 
-	while (stream >> token)
-	{
-		if (!parsingKeys)
-		{
-			if (token[0] == '#')
-				channels.push_back(token);
-			else 
-			{
-				parsingKeys = true;
-				keys.push_back(token);
-			}
-		}
-		else
-			keys.push_back(token);
-	}
+    if (!(stream >> channelsList))
+		return {};
+
+    std::getline(stream, keysList);
+	if (!keysList.empty() && keysList[0] == ' ')
+		keysList.erase(0, 1);
+
+	std::vector<std::string> channels, keys;
+	std::stringstream chStream(channelsList), keyStream(keysList);
+
+	std::string token;
+	while (std::getline(chStream, token, ','))
+		channels.push_back(token);
+
+	while (std::getline(keyStream, token, ','))
+		keys.push_back(token);
 
 	for (size_t i = 0; i < channels.size(); ++i)
 	{
@@ -1057,6 +992,79 @@ std::map<std::string, std::string>	Server::MapChannels( const std::string& messa
 	}
 	return (channelMap);
 }
+
+void Server::Join(Client& client, const std::string& message)
+{
+	std::map<std::string, std::string>allChannels = MapChannels(message);
+	if (allChannels.empty())
+		return ;
+
+	for (auto it_map = allChannels.begin();it_map != allChannels.end(); ++it_map)
+	{
+		std::string channel = it_map->first;
+		std::string key = it_map->second;
+		if (channel.empty() || channel[0] != '#')
+		{
+			// ERR_BADCHANMASK
+			SendToClient(client, ":" + _name + " 476 " + client.getNick() + " " + channel + ":invalid channel name" + "\r\n");
+			continue ;
+		}
+
+		// We look for existing channel, and if it does not exist, we create it
+		auto [it, inserted] = _channels.try_emplace(channel, Channel(channel, key, "", false, false));
+	
+		// check if priovided key matches
+    	if (!it->second.getKey().empty() && it->second.getKey() != key)
+    	{
+    	    SendToClient(client, ":" + _name + " 475 " + client.getNick() + " " + channel + " :bad channel key\r\n");
+    	    continue ;
+    	}
+	
+		// check if server has imposed limit
+		if (it->second.getMaxMembers())
+		{
+			// check if there is space
+			if (it->second.getNbMembers() >= it->second.getNumberMaxMembers())
+			{
+				SendToClient(client, ":" + _name + " 471 " + client.getNick() + " " + channel + " :channel is full\r\n");
+				continue ;
+			}
+		}
+
+		// avoid double join
+		if (it->second.isMember(&client))
+			continue ;
+
+		it->second.addMember(&client);
+		if (it->second.isMember(&client))
+		{
+			SendToClient(client, ":" + client.getNick() + " JOIN " + channel + "\r\n");
+			std::string namesList;
+			for (Client* member : it->second.getMembers())
+			{
+				if (it->second.isOperator(member))
+					namesList += "@" + member->getNick() + " ";
+				else
+					namesList += member->getNick() + " ";
+			}
+			SendToClient(client, ":" + _name + " 353 " + client.getNick() + " = " + channel + " :" + namesList + "\r\n");
+			SendToClient(client, ":" + _name + " 366 " + client.getNick() + " " + channel + " :End of /NAMES list.\r\n");
+			if (!it->second.getTopic().empty())
+			{
+				SendToClient(client, ":" + _name + " 332 " + client.getNick() + " " + channel + " :" + it->second.getTopic() + "\r\n");
+				
+				SendToClient(client, ":" + _name + " 333 " + client.getNick() + " " + channel + " " + it->second.getSetter() + " " + std::to_string(it->second.getTopicTime()) + "\r\n");
+			}
+			else
+			{
+				SendToClient(client, ":" + _name + " 331 " + client.getNick() + " " + channel + " :No topic is set\r\n");
+			}
+			SendToChannel(it->second.getName(), ":" + client.getNick() + "!~" + client.getNick() + "@" + client.getHost() + " JOIN " + it->second.getName() + "\r\n", &client, NORMAL_MSG); // why does this crap is persisting?
+			//:fdessoy!~fdessoy@87-92-251-103.rev.dnainternet.fi JOIN #SUPER_BBQ
+		}
+	}
+}
+
 
 void	Server::Topic(Client& client, const std::string& message)
 {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/07 12:14:25 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/02/07 12:17:38 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -693,7 +693,7 @@ void Server::Mode(Client& client, const std::string& message)
 						Client* possibleOperator = it->second.retrieveClient(targetUser);
 						if (possibleOperator != nullptr)
 						{
-							it->second.removeOperator(&client, possibleOperator, false);
+							it->second.removeOperator(&client, possibleOperator);
 							SendToChannel(it->second.getName(), messageSyntax + " " + targetUser + "\r\n", &client, UNIVERSAL_MSG);
 						}
 						else
@@ -947,7 +947,7 @@ void Server::Part(Client& client, const std::string& message)
 		std::string partSyntax = ":" + client.getNick() + "!~" + client.getNick() + "@" + client.getHost() + " PART " + channel + "\r\n";
 		SendToChannel(channel, partSyntax, &client, NORMAL_MSG);
 		if (it->second.isOperator(&client))
-			it->second.removeOperator(&client, nullptr, true);
+			it->second.removeOperator(&client, nullptr);
 		it->second.removeMember(&client);
 		SendToClient(client, partSyntax);
 		if (it->second.isChannelEmpty())

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: fdessoy- <fdessoy-@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:38 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/07 12:06:04 by fdessoy-         ###   ########.fr       */
+/*   Updated: 2025/02/07 12:14:25 by fdessoy-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -551,10 +551,7 @@ void Server::Mode(Client& client, const std::string& message)
 
 	// check if target is either user or channel
 	if (modeChanges.empty() || target.empty())
-	{
-		SendToClient(client, ":" + _name + " 221 " + "RPL_UMODEIS " + client.getModes() + "\r\n");
 		return ;
-	}
 	if (target[0] == '#') // checking for channel
 	{
 		for (auto it = _channels.begin(); it != _channels.end(); ++it)


### PR DESCRIPTION
`JOIN` and `PART` now can handle more input.

### Major

Users are now capable of joining and parting from multiple channels.

### Minor

1. `removeOperator()` does not have a boolean as paramter anymore. Instead, we are checking if the `target` is a `nullptr`;
2. Took away extra `SendToClient()` message `221 RPL_UMODEIS`;
3. Fixed a bug in the MODE logic where it would not change channels MODE flags if there were extra channels.