### PR TITLE
Fix: segfaults and signing handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME		=	ircserv
 NAME_ASAN	=	ircsan
 COMP		=	c++
-FLAGS		=	-Wall -Werror -Wextra -std=c++17
+FLAGS		=	-Wall -Werror -Wextra -std=c++17 -g
 ASAN_FLAGS	= 	-Wall -Werror -Wextra -std=c++17 -fsanitize=address
 
 SRC_DIR		=	src

--- a/inc/Server.hpp
+++ b/inc/Server.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include "Client.hpp"
 #include "Channel.hpp"
+#include <signal.h>
 
 #define SERVER_NAME "Zorg"
 #define JUST_JOINED 1
@@ -89,4 +90,6 @@ public:
     void initializeCommandHandlers();
     std::vector<std::string> splitMessages(const std::string& message);
     void checkClientTimeouts();
+	bool isShutdownRequested();
+	void shutdownServer();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akuburas <akuburas@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/08 09:49:45 by akuburas          #+#    #+#             */
-/*   Updated: 2025/02/18 16:07:28 by akuburas         ###   ########.fr       */
+/*   Updated: 2025/03/11 12:10:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,11 @@
 #include <cstring>
 #include <fcntl.h>
 #include <poll.h>
+#include <signal.h>
 
+
+
+extern "C" void sigintHandler(int sig);
 
 bool	isDigit(std::string str)
 {
@@ -124,6 +128,18 @@ int main(int argc, char **argv)
 		close(irc_server.getSocket());
 		return (EXIT_FAILURE);
 	}
+	
+	// Set up signal handler for graceful shutdown
+	struct sigaction sa;
+	sa.sa_handler = sigintHandler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	if (sigaction(SIGINT, &sa, NULL) == -1) {
+		perror("Error setting up signal handler");
+		close(irc_server.getSocket());
+		return EXIT_FAILURE;
+	}
+	
 	std::cout << "Server is listening in non-blocking mode" << std::endl;
 	std::cout << "Port: " << port << std::endl;
 	std::cout << "Pass: " << password << std::endl;


### PR DESCRIPTION
### Major

1.  Fixed segfault problems when a client is disconnected due to inactivity. 
* Before kicking the client out, we make a copy of the client vector so the inactive clients are first detected and kicked out in a second step.
* The disconnection step is improved, also cleaning up the channel operators and empty channels

2. `SIGINT` handling.
* When the signal is detected, the Server is cleaned up, including removing the client, channels, and pools.

### Minor
* When a partial message is detected, the server prints out its contents instead of being silent. The previous logic stays in place: if the message is incomplete, just append and do not interpret it.
